### PR TITLE
feat: adds support for installing llvm or cranelift as optional deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,20 @@ Python module which is an SDK for using WebAssembly (wasm) compiled
 # Getting Started
 ## Install the module
 
+You may choose to use either the `cranelift` or `llvm` compiler package as follows: 
+
 ```
-pip install opa-wasm
+pip install opa-wasm[cranelift]
 ```
+or
+```
+pip install opa-wasm[llvm]
+```
+
+For builds that target AWS Lambda as an execution environment, it is recommended to use cranelift. This avoids 
+the need to bundle additional binary dependencies as part of the lambda package.
+
+See the [wasmer-python](https://github.com/wasmerio/wasmer-python) docs for more information
 
 ## Usage
 

--- a/opa_wasm/opa_wasm.py
+++ b/opa_wasm/opa_wasm.py
@@ -5,8 +5,11 @@ from typing import Union
 
 from wasmer import Memory, MemoryType
 from wasmer import engine, Store, Module, Instance, ImportObject, Function
-from wasmer_compiler_llvm import Compiler
 
+try:
+    from wasmer_compiler_cranelift import Compiler
+except ImportError:
+    from wasmer_compiler_llvm import Compiler
 
 class OPAPolicy:
     STORE = Store(engine.JIT(Compiler))

--- a/poetry.lock
+++ b/poetry.lock
@@ -139,6 +139,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "wasmer-compiler-cranelift"
+version = "1.0.0"
+description = "The Cranelift compiler for the `wasmer` package (to compile WebAssembly module)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "wasmer-compiler-llvm"
 version = "1.0.0"
 description = "Python extension to run WebAssembly binaries"
@@ -149,7 +157,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "1fe4fff953e1900e608c78e07d4954243034b01b54ab84a90d4e55d645d36a41"
+content-hash = "21fdba1e23ba3dc203ac694e5c4b644805c096070fc72123e334ec73500daf7c"
 
 [metadata.files]
 atomicwrites = [
@@ -265,6 +273,22 @@ wasmer = [
     {file = "wasmer-1.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:04e5d51eed336be0e1bf1445aa032fc34466b77220c26732b8990df872f29e92"},
     {file = "wasmer-1.0.0-cp39-none-win_amd64.whl", hash = "sha256:690c5ed46a98e91bc638f52a25e5011c5baa1ef0581f414018eb7aa0e7f844bc"},
     {file = "wasmer-1.0.0-py3-none-any.whl", hash = "sha256:427e9c5e5301a453a09b8b9ceb8c793d85411b8f45e54c9c0d801566dd8d214e"},
+]
+wasmer-compiler-cranelift = [
+    {file = "wasmer_compiler_cranelift-1.0.0-cp36-cp36m-macosx_10_7_x86_64.whl", hash = "sha256:764a51e363db28da1b4aaf3ac0aac42125d0f6af38ffdeb2a9d5aa534e500677"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:456d525fa1bd420c738684a89afcc298f5013f8a1f637a80e16ef5a3ee2782c0"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp36-none-win_amd64.whl", hash = "sha256:24f97e00e2a4261e242857dc7438737f88f7e0b5d2d024e5b96ad5e20f3ea19c"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:56384961fb0f853ead5b2947b95c45a029a0eb203588bfc5386a27ebeab3f13f"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:cd7812d1688b9b5f8ed9fe57831cf167baec5c7e070576f4be1f73ab2ec4f49d"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp37-none-win_amd64.whl", hash = "sha256:d795b0bfdc5c034d9bd61eb5c94e1caca8e0205bf17540bf81e993897385afd6"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:413cb45eb8f40c3b09c7cee75a10f025bb85ca408be865c5fbcb86766d5e318d"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8e9c63f1275d674ab0aba1bb64620d0e2ec79efad96259759fa79d01f951f639"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp38-none-win_amd64.whl", hash = "sha256:23a4f338f4d972e5273173c370d349222de7f332bc945754dbfeff91ece9927f"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:8d3355eb8ccdb742c31fde104c5f6dff772d27f22712d898a22bef1ced302cfd"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bcedc1abf0518afcfc60cbd0fcac2d636bac02504a1cb9a42c9cc88445673929"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:4b15a38b0a22c921ea112a50bdc86ca7a302ed2fd082e57a5c409781b960fbba"},
+    {file = "wasmer_compiler_cranelift-1.0.0-cp39-none-win_amd64.whl", hash = "sha256:dab69907c3b358ad538846af3f6e9f04ed8a88b40eb63ad434a1098b2c62ee2d"},
+    {file = "wasmer_compiler_cranelift-1.0.0-py3-none-any.whl", hash = "sha256:081fdc24eaaac951b84efb6c7e439ccbda8b46f512b8ae2707bcb29763d15a49"},
 ]
 wasmer-compiler-llvm = [
     {file = "wasmer_compiler_llvm-1.0.0-cp36-cp36m-macosx_10_7_x86_64.whl", hash = "sha256:367a686655021cf19e026f5a2822a4d212d9d673dc3178213da087d98dc2e018"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opa-wasm"
-version = "0.2.0"
+version = "0.3.0"
 description = "Open Policy Agent WebAssembly SDK for Python"
 authors = ["Imtiaz Mangerah <Imtiaz_Mangerah@a2d24.com>"]
 license = "MIT"
@@ -14,12 +14,19 @@ documentation = "https://github.com/a2d24/python-opa-wasm"
 [tool.poetry.dependencies]
 python = "^3.8"
 wasmer = "^1.0.0"
-wasmer-compiler-llvm = "^1.0.0"
+wasmer-compiler-llvm = {version = "^1.0.0", optional = true}
+wasmer-compiler-cranelift = {version = "^1.0.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"
 pytest-cov = "^2.12.1"
+wasmer-compiler-llvm = "^1.0.0"
+wasmer-compiler-cranelift = "^1.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.extras]
+cranelift = ["wasmer-compiler-cranelift"]
+llvm = ["wasmer-compiler-llvm"]


### PR DESCRIPTION
Adds `wasmer-compiler-llvm` and `wasmer-compiler-cranelift` as optional deps. Should both be present, cranelift will be preferred.